### PR TITLE
Footer app menu, rebindable hotkey, and movable Settings window

### DIFF
--- a/core/src/common/mod.rs
+++ b/core/src/common/mod.rs
@@ -21,6 +21,99 @@ pub struct AppState {
     /// array of tables) so plugin/preference ids with dots stay simple keys.
     #[serde(default)]
     pub preferences: Vec<StoredPreference>,
+    /// The user's chosen global launcher hotkey. `None` means "use the default"
+    /// (Alt/Option + Space); `#[serde(default)]` keeps older state files valid.
+    #[serde(default)]
+    pub launcher_hotkey: Option<Hotkey>,
+}
+
+/// A platform-agnostic description of a global hotkey: the held modifiers plus
+/// the physical key, identified by its W3C UI Events `code` name (e.g. `Space`,
+/// `KeyK`). Kept free of any platform crate so it can be persisted here and
+/// converted to the OS registration type in the UI layer.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct Hotkey {
+    #[serde(default)]
+    pub ctrl: bool,
+    #[serde(default)]
+    pub alt: bool,
+    #[serde(default)]
+    pub shift: bool,
+    /// The "logo" / Super / Command / Windows key.
+    #[serde(default)]
+    pub meta: bool,
+    /// The physical key's W3C `code` name, e.g. `"Space"`, `"KeyK"`, `"Digit1"`.
+    pub code: String,
+}
+
+impl Default for Hotkey {
+    /// Alt/Option + Space — the launcher's historical default.
+    fn default() -> Self {
+        Self {
+            ctrl: false,
+            alt: true,
+            shift: false,
+            meta: false,
+            code: "Space".to_string(),
+        }
+    }
+}
+
+impl Hotkey {
+    /// Whether at least one modifier is held. A modifier-less hotkey is allowed
+    /// but easy to trigger accidentally, so callers may wish to warn.
+    pub fn has_modifier(&self) -> bool {
+        self.ctrl || self.alt || self.shift || self.meta
+    }
+
+    /// The hotkey rendered as a sequence of keycap labels (modifiers first, in
+    /// the conventional ⌃⌥⇧⌘ order, then the key), for display as chips.
+    pub fn keycaps(&self) -> Vec<String> {
+        let mut caps = Vec::new();
+        if self.ctrl {
+            caps.push("⌃".to_string());
+        }
+        if self.alt {
+            caps.push("⌥".to_string());
+        }
+        if self.shift {
+            caps.push("⇧".to_string());
+        }
+        if self.meta {
+            caps.push("⌘".to_string());
+        }
+        caps.push(prettify_code(&self.code));
+        caps
+    }
+}
+
+/// Turn a W3C key `code` into a short display label: `KeyK` → `K`, `Digit1` →
+/// `1`, `ArrowUp` → `↑`, and a handful of other common glyphs; anything else is
+/// shown as-is.
+fn prettify_code(code: &str) -> String {
+    match code {
+        "Space" => "Space".to_string(),
+        "Enter" | "NumpadEnter" => "↵".to_string(),
+        "Tab" => "⇥".to_string(),
+        "Escape" => "esc".to_string(),
+        "ArrowUp" => "↑".to_string(),
+        "ArrowDown" => "↓".to_string(),
+        "ArrowLeft" => "←".to_string(),
+        "ArrowRight" => "→".to_string(),
+        "Backslash" => "\\".to_string(),
+        "Slash" => "/".to_string(),
+        "Period" => ".".to_string(),
+        "Comma" => ",".to_string(),
+        _ => {
+            if let Some(letter) = code.strip_prefix("Key") {
+                letter.to_string()
+            } else if let Some(digit) = code.strip_prefix("Digit") {
+                digit.to_string()
+            } else {
+                code.to_string()
+            }
+        }
+    }
 }
 
 /// One persisted plugin preference value.
@@ -137,6 +230,17 @@ impl AppState {
         self.preferences
             .iter()
             .map(|pref| (pref.plugin.as_str(), pref.id.as_str(), pref.value.clone()))
+    }
+
+    /// The configured launcher hotkey, or the default (Alt/Option + Space) when
+    /// the user has not set one.
+    pub fn launcher_hotkey(&self) -> Hotkey {
+        self.launcher_hotkey.clone().unwrap_or_default()
+    }
+
+    /// Persist the user's chosen launcher hotkey.
+    pub fn set_launcher_hotkey(&mut self, hotkey: Hotkey) {
+        self.launcher_hotkey = Some(hotkey);
     }
 
     pub fn get_score(&self, entity: &super::Entity) -> u32 {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::plugins::{
 use anyhow::Result;
 pub use application::App;
 pub use application::Application;
-pub use common::AppState;
+pub use common::{AppState, Hotkey};
 
 mod application;
 pub mod clipboard;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -88,6 +88,7 @@ impl Raycast {
             }
             Message::ExitApp => self.close_launcher(),
             Message::Show => self.show_launcher(),
+            Message::Toggle => self.toggle_launcher(),
             Message::QuitAgent => self.quit_agent(),
             Message::WindowClosed(id) => self.on_window_closed(id),
             Message::IcedEvent(event) => self.handle_iced_event(event),
@@ -211,6 +212,21 @@ impl Raycast {
                     ])
                 }
             }
+        }
+    }
+
+    /// Toggle the launcher: close it if it's showing, otherwise show it. Bound to
+    /// the global shortcut so pressing it again dismisses the launcher.
+    fn toggle_launcher(&mut self) -> Task<Message> {
+        #[cfg(target_os = "linux")]
+        let visible = self.launcher.is_some();
+        #[cfg(not(target_os = "linux"))]
+        let visible = self.launcher_visible;
+
+        if visible {
+            self.close_launcher()
+        } else {
+            self.show_launcher()
         }
     }
 
@@ -509,8 +525,10 @@ fn settings_window_settings() -> iced::window::Settings {
     }
 }
 
-/// A subscription that listens on the IPC control socket and emits [`Message::Show`]
-/// whenever a bare invocation asks the resident agent to open the launcher.
+/// A subscription that listens on the IPC control socket and emits
+/// [`Message::Toggle`] whenever a bare invocation asks the resident agent to open
+/// the launcher. This is the launcher shortcut on Linux (the compositor keybind
+/// re-runs the binary), so it toggles: a second press dismisses the launcher.
 fn show_stream() -> impl iced::futures::Stream<Item = Message> {
     use iced::futures::channel::mpsc::Sender;
     iced::stream::channel(4, |output: Sender<Message>| async move {
@@ -520,7 +538,7 @@ fn show_stream() -> impl iced::futures::Stream<Item = Message> {
         std::thread::spawn(move || {
             if let Some(listener) = crate::ipc::bind() {
                 crate::ipc::serve(listener, || {
-                    let _ = sender.try_send(Message::Show);
+                    let _ = sender.try_send(Message::Toggle);
                 });
             }
         });
@@ -539,6 +557,9 @@ pub enum Message {
     ExitApp,
     /// Show the launcher window/surface (IPC trigger / first launch).
     Show,
+    /// Toggle the launcher (from the global shortcut): show it, or close it if
+    /// it is already open.
+    Toggle,
     /// Quit the resident agent entirely (e.g. from the tray).
     QuitAgent,
     /// A window (launcher or Plugin Manager) was closed.

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -11,8 +11,7 @@ use iced_layershell::to_layer_message;
 use crate::prism;
 use crate::prism::PrismEvent;
 
-/// Initial size of the Plugin Manager window (a normal xdg_toplevel on Linux).
-#[cfg(target_os = "linux")]
+/// Initial size of the Settings (Plugin Manager) window.
 const SETTINGS_SIZE: (u32, u32) = (900, 620);
 /// Size of the launcher surface / window.
 const LAUNCHER_SIZE: (u32, u32) = (700, 500);
@@ -31,9 +30,9 @@ pub struct Raycast {
     /// Non-Linux only: whether the persistent launcher window is currently shown.
     #[cfg(not(target_os = "linux"))]
     launcher_visible: bool,
-    /// The Plugin Manager window while it is open (a separate xdg_toplevel on
-    /// Linux; elsewhere the manager renders inline in the launcher window).
-    #[cfg(target_os = "linux")]
+    /// The Settings (Plugin Manager) window while it is open — a separate,
+    /// movable window on every platform (a normal xdg_toplevel on Linux; a
+    /// borderless `iced::window` elsewhere).
     settings_window: Option<iced::window::Id>,
     /// The `wl-paste --watch` clipboard recorder, owned so it stops when the
     /// agent quits (and dies with the agent via `PR_SET_PDEATHSIG` on a crash).
@@ -54,7 +53,6 @@ impl Raycast {
             launcher: None,
             #[cfg(not(target_os = "linux"))]
             launcher_visible: false,
-            #[cfg(target_os = "linux")]
             settings_window: None,
             // Start the continuous clipboard recorder, owned by this agent.
             #[cfg(target_os = "linux")]
@@ -80,7 +78,7 @@ impl Raycast {
         // main thread with the event loop already running; `update` is exactly
         // that context. `ensure_installed` is a one-time (Once-guarded) setup.
         #[cfg(not(target_os = "linux"))]
-        crate::tray_native::ensure_installed();
+        crate::tray_native::ensure_installed(&self.app_state.launcher_hotkey());
 
         match message {
             Message::PrismEvent(prism_event) => self.handle_prism_event(prism_event),
@@ -92,8 +90,63 @@ impl Raycast {
             Message::Show => self.show_launcher(),
             Message::QuitAgent => self.quit_agent(),
             Message::WindowClosed(id) => self.on_window_closed(id),
+            Message::IcedEvent(event) => self.handle_iced_event(event),
+            Message::DragSettingsWindow => match self.settings_window {
+                Some(id) => iced::window::drag(id),
+                None => Task::none(),
+            },
+            Message::Ignore => Task::none(),
+            // On Linux the layer-shell message macro adds further variants; on
+            // other platforms every variant is already matched above.
+            #[allow(unreachable_patterns)]
             _ => Task::none(),
         }
+    }
+
+    /// While the launcher-hotkey recorder is armed, turn the next real key press
+    /// into a new hotkey: persist it, re-register the global shortcut, and update
+    /// the settings display. Ignored entirely when not recording.
+    fn handle_iced_event(&mut self, event: Event) -> Task<Message> {
+        use iced::keyboard::{self, key};
+
+        if !self.prism.is_recording_hotkey() {
+            return Task::none();
+        }
+
+        let iced::Event::Keyboard(keyboard::Event::KeyPressed {
+            physical_key: key::Physical::Code(code),
+            modifiers,
+            ..
+        }) = event
+        else {
+            return Task::none();
+        };
+
+        let code = format!("{code:?}");
+        // Wait for a non-modifier key; Escape cancels (handled by Prism).
+        if code == "Escape" || is_modifier_code(&code) {
+            return Task::none();
+        }
+
+        let hotkey = core::Hotkey {
+            ctrl: modifiers.control(),
+            alt: modifiers.alt(),
+            shift: modifiers.shift(),
+            meta: modifiers.logo(),
+            code,
+        };
+
+        self.app_state.set_launcher_hotkey(hotkey.clone());
+        if let Err(error) = self.app_state.save() {
+            eprintln!("Failed to save hotkey: {error}");
+        }
+        #[cfg(not(target_os = "linux"))]
+        if let Err(error) = crate::tray_native::rebind(&hotkey) {
+            eprintln!("Failed to rebind hotkey: {error}");
+        }
+        self.prism.set_launcher_hotkey(hotkey);
+
+        Task::none()
     }
 
     /// Launch the selected application/command (the old `Run` body).
@@ -201,11 +254,13 @@ impl Raycast {
             self.launcher = None;
             return Task::none();
         }
-        #[cfg(target_os = "linux")]
         if Some(id) == self.settings_window {
             self.settings_window = None;
             self.prism.close_plugin_manager();
+            #[cfg(target_os = "linux")]
             return self.set_launcher_layer(Layer::Top);
+            #[cfg(not(target_os = "linux"))]
+            return Task::none();
         }
         Task::none()
     }
@@ -240,18 +295,41 @@ impl Raycast {
         task
     }
 
+    /// Route a Prism event, opening/closing the Settings window as the manager
+    /// opens and closes. Settings is its own borderless, movable window; opening
+    /// it hides the launcher (as Raycast dismisses the launcher for Preferences).
     #[cfg(not(target_os = "linux"))]
     fn handle_prism_event(&mut self, prism_event: PrismEvent) -> Task<Message> {
-        self.prism
+        let was_open = self.prism.is_plugin_manager_open();
+        let task = self
+            .prism
             .update(prism_event, &mut self.app_state)
-            .map(map_prism_event)
+            .map(map_prism_event);
+        let now_open = self.prism.is_plugin_manager_open();
+
+        if now_open && !was_open && self.settings_window.is_none() {
+            let (id, open) = iced::window::open(settings_window_settings());
+            self.settings_window = Some(id);
+            return Task::batch([
+                task,
+                open.map(|_| Message::Ignore),
+                iced::window::gain_focus(id),
+                self.close_launcher(),
+            ]);
+        }
+        if !now_open && was_open {
+            return Task::batch([task, self.close_settings_window()]);
+        }
+        task
     }
 
-    /// Close the Plugin Manager window if one is open.
-    #[cfg(target_os = "linux")]
+    /// Close the Settings window if one is open.
     fn close_settings_window(&mut self) -> Task<Message> {
         match self.settings_window.take() {
+            #[cfg(target_os = "linux")]
             Some(id) => Task::done(Message::RemoveWindow(id)),
+            #[cfg(not(target_os = "linux"))]
+            Some(id) => iced::window::close(id),
             None => Task::none(),
         }
     }
@@ -297,7 +375,8 @@ impl Raycast {
     /// Plugin Manager window. Elsewhere the manager renders inline in the
     /// launcher window.
     pub fn view(&self, id: iced::window::Id) -> Element<'_, Message> {
-        #[cfg(target_os = "linux")]
+        // The Settings window (its own window on every platform) renders the
+        // Plugin Manager; every other window renders the launcher.
         if Some(id) == self.settings_window {
             return match self.prism.plugin_manager_view() {
                 Some(view) => view.map(Message::PrismEvent),
@@ -305,16 +384,7 @@ impl Raycast {
             };
         }
 
-        #[cfg(target_os = "linux")]
-        let content = self.prism.view();
-        #[cfg(not(target_os = "linux"))]
-        let content = match self.prism.plugin_manager_view() {
-            Some(view) => view,
-            None => self.prism.view(),
-        };
-
-        let _ = id;
-        container(content.map(Message::PrismEvent)).into()
+        container(self.prism.view().map(Message::PrismEvent)).into()
     }
 
     pub fn style(&self, _theme: &iced::Theme) -> iced::theme::Style {
@@ -330,6 +400,8 @@ fn map_prism_event(event: PrismEvent) -> Message {
     match event {
         PrismEvent::Run => Message::Run,
         PrismEvent::ExitApp => Message::ExitApp,
+        PrismEvent::QuitApp => Message::QuitAgent,
+        PrismEvent::DragSettingsWindow => Message::DragSettingsWindow,
         e => Message::PrismEvent(e),
     }
 }
@@ -418,6 +490,25 @@ fn launcher_window_settings() -> iced::window::Settings {
     }
 }
 
+/// Window settings for the Settings surface (non-Linux): a borderless, movable,
+/// normal-level window. It draws its own title bar (dragged via
+/// [`Message::DragSettingsWindow`]); closing it does not exit the daemon.
+#[cfg(not(target_os = "linux"))]
+fn settings_window_settings() -> iced::window::Settings {
+    iced::window::Settings {
+        size: iced::Size {
+            width: SETTINGS_SIZE.0 as f32,
+            height: SETTINGS_SIZE.1 as f32,
+        },
+        position: iced::window::Position::Centered,
+        resizable: false,
+        decorations: false,
+        transparent: true,
+        exit_on_close_request: false,
+        ..Default::default()
+    }
+}
+
 /// A subscription that listens on the IPC control socket and emits [`Message::Show`]
 /// whenever a bare invocation asks the resident agent to open the launcher.
 fn show_stream() -> impl iced::futures::Stream<Item = Message> {
@@ -452,4 +543,19 @@ pub enum Message {
     QuitAgent,
     /// A window (launcher or Plugin Manager) was closed.
     WindowClosed(iced::window::Id),
+    /// Begin an interactive drag of the Settings window (from its title bar).
+    DragSettingsWindow,
+    /// A no-op, used to discard a window command's output.
+    Ignore,
+}
+
+/// Whether a W3C key `code` names a modifier key (so the hotkey recorder keeps
+/// waiting for a real key rather than binding e.g. `ControlLeft`).
+fn is_modifier_code(code: &str) -> bool {
+    code.starts_with("Control")
+        || code.starts_with("Alt")
+        || code.starts_with("Shift")
+        || code.starts_with("Meta")
+        || code.starts_with("Super")
+        || code.starts_with("Hyper")
 }

--- a/ui/src/prism/keybindings.rs
+++ b/ui/src/prism/keybindings.rs
@@ -35,6 +35,7 @@ pub enum KeyAction {
     EscapePressed,
     ToggleActions,
     OpenPluginManager,
+    QuitApp,
 }
 
 pub fn map_key_to_action(key: &keyboard::Key, modifiers: keyboard::Modifiers) -> Option<KeyAction> {
@@ -49,6 +50,10 @@ pub fn map_key_to_action(key: &keyboard::Key, modifiers: keyboard::Modifiers) ->
             // ⌘, / Ctrl+, opens the Plugin Manager (settings), like Raycast.
             if c.as_str() == "," {
                 return Some(KeyAction::OpenPluginManager);
+            }
+            // ⌘Q / Ctrl+Q quits the app (matches the app-menu shortcut).
+            if c.as_str().eq_ignore_ascii_case("q") {
+                return Some(KeyAction::QuitApp);
             }
         }
         return None;

--- a/ui/src/prism/mod.rs
+++ b/ui/src/prism/mod.rs
@@ -57,6 +57,7 @@ impl Prism {
             command_held: false,
             show_actions: false,
             actions_selected_index: 0,
+            show_menu: false,
             recent_arguments: Vec::new(),
             views: Vec::new(),
             image_cache: std::collections::HashMap::new(),
@@ -88,17 +89,29 @@ impl Prism {
     pub fn update(&mut self, message: PrismEvent, app_state: &mut AppState) -> Task<PrismEvent> {
         // While the Plugin Manager is open it owns the window; ignore launcher
         // navigation/search events. Its own events (and Escape/exit) still pass.
-        if self.state.plugin_manager.is_some()
-            && !matches!(
-                message,
-                PrismEvent::PluginManager(_)
-                    | PrismEvent::OpenPluginManager
-                    | PrismEvent::EscapePressed
-                    | PrismEvent::ExitApp
-                    | PrismEvent::ModifiersChanged(_)
-            )
-        {
-            return Task::none();
+        // While recording a hotkey it narrows further so a stray chord (⌘Q etc.)
+        // can't fire mid-capture — only its own events and Escape (cancel) pass.
+        if let Some(pm) = self.state.plugin_manager.as_ref() {
+            let allowed = if pm.recording_hotkey {
+                matches!(
+                    message,
+                    PrismEvent::PluginManager(_) | PrismEvent::EscapePressed
+                )
+            } else {
+                matches!(
+                    message,
+                    PrismEvent::PluginManager(_)
+                        | PrismEvent::OpenPluginManager
+                        | PrismEvent::EscapePressed
+                        | PrismEvent::ExitApp
+                        | PrismEvent::QuitApp
+                        | PrismEvent::DragSettingsWindow
+                        | PrismEvent::ModifiersChanged(_)
+                )
+            };
+            if !allowed {
+                return Task::none();
+            }
         }
 
         match message {
@@ -115,6 +128,7 @@ impl Prism {
                 self.state.plugin_manager = Some(pm);
                 // Clear any transient launcher UI that would linger underneath.
                 self.state.show_actions = false;
+                self.state.show_menu = false;
                 self.state.show_argument_input = false;
                 self.state.is_argument_input_active = false;
                 focus(focus_search)
@@ -165,6 +179,7 @@ impl Prism {
                 self.state.show_argument_input = false;
                 self.state.is_argument_input_active = false;
                 self.state.show_actions = false;
+                self.state.show_menu = false;
                 self.state.actions_selected_index = 0;
                 // Query-driven plugin results (e.g. calculator) are produced
                 // fresh for this query and shown ahead of the filtered list;
@@ -374,6 +389,21 @@ impl Prism {
                 Task::none()
             }
 
+            PrismEvent::ToggleMenu => {
+                self.state.show_menu = !self.state.show_menu;
+                // The app menu and the actions popover are mutually exclusive.
+                self.state.show_actions = false;
+                Task::none()
+            }
+
+            // Bubble up to the app boundary, where `map_prism_event` turns it
+            // into `Message::QuitAgent` (a full quit, not just hiding the
+            // launcher like `ExitApp`).
+            PrismEvent::QuitApp => Task::done(PrismEvent::QuitApp),
+
+            // Bubble up so the app can start an interactive window drag.
+            PrismEvent::DragSettingsWindow => Task::done(PrismEvent::DragSettingsWindow),
+
             PrismEvent::InvokeAction(index) => {
                 self.state.actions_selected_index = index;
 
@@ -407,9 +437,13 @@ impl Prism {
             }
 
             PrismEvent::EscapePressed => {
-                // The Plugin Manager captures Escape: first close its confirm
-                // dialog, then the manager itself.
+                // The Plugin Manager captures Escape: first cancel hotkey
+                // recording, then close its confirm dialog, then the manager.
                 if let Some(pm) = self.state.plugin_manager.as_mut() {
+                    if pm.recording_hotkey {
+                        pm.recording_hotkey = false;
+                        return Task::none();
+                    }
                     if pm.confirming {
                         pm.confirming = false;
                         return Task::none();
@@ -422,6 +456,9 @@ impl Prism {
                 }
                 if self.state.show_actions {
                     self.state.show_actions = false;
+                    Task::none()
+                } else if self.state.show_menu {
+                    self.state.show_menu = false;
                     Task::none()
                 } else if self.state.is_argument_input_active {
                     self.state.argument = Option::None;
@@ -651,6 +688,10 @@ impl Prism {
 
         match event {
             PmEvent::Close => {}
+            PmEvent::SelectTab(tab) => pm.tab = tab,
+            // Arm/disarm hotkey capture; the app-level key handler records the
+            // next real key press (see `Raycast::handle_iced_event`).
+            PmEvent::RecordHotkey => pm.recording_hotkey = !pm.recording_hotkey,
             PmEvent::Select(id) => pm.selected_id = Some(id),
             PmEvent::ToggleEnabled(id) => {
                 if let Some(plugin) = pm.plugins.iter_mut().find(|p| p.id == id) {
@@ -1055,6 +1096,7 @@ impl Prism {
                     keybindings::KeyAction::EscapePressed => PrismEvent::EscapePressed,
                     keybindings::KeyAction::ToggleActions => PrismEvent::ToggleActions,
                     keybindings::KeyAction::OpenPluginManager => PrismEvent::OpenPluginManager,
+                    keybindings::KeyAction::QuitApp => PrismEvent::QuitApp,
                 })
             }
             // Track the command/ctrl modifier so we can suppress a printable
@@ -1136,6 +1178,23 @@ impl Prism {
     /// Force the Plugin Manager closed (e.g. its window was closed externally).
     pub fn close_plugin_manager(&mut self) {
         self.state.plugin_manager = None;
+    }
+
+    /// Whether the settings screen is armed to capture a new launcher hotkey.
+    pub fn is_recording_hotkey(&self) -> bool {
+        self.state
+            .plugin_manager
+            .as_ref()
+            .is_some_and(|pm| pm.recording_hotkey)
+    }
+
+    /// Commit a newly-recorded launcher hotkey to the settings display and stop
+    /// recording. Persisting and re-registering happen at the app boundary.
+    pub fn set_launcher_hotkey(&mut self, hotkey: core::Hotkey) {
+        if let Some(pm) = self.state.plugin_manager.as_mut() {
+            pm.launcher_hotkey = hotkey;
+            pm.recording_hotkey = false;
+        }
     }
 
     /// The Plugin Manager screen, when open. Rendered in its own window on
@@ -1225,7 +1284,7 @@ impl Prism {
                 search_section,
                 widgets::divider(),
                 middle,
-                widgets::footer(selected_entry.map(|e| &e.entry)),
+                widgets::footer(selected_entry.map(|e| &e.entry), PrismEvent::ToggleMenu),
             ]
             .into()
         };
@@ -1261,6 +1320,26 @@ impl Prism {
             return iced::widget::stack![main, overlay].into();
         }
 
+        // Overlay the app menu (Settings / Quit), anchored bottom-left above the
+        // footer's hamburger button.
+        if self.state.show_menu {
+            let popover = widgets::app_menu(PrismEvent::OpenPluginManager, PrismEvent::QuitApp);
+
+            let overlay = container(popover)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_x(iced::alignment::Horizontal::Left)
+                .align_y(iced::alignment::Vertical::Bottom)
+                .padding(iced::Padding {
+                    top: 0.0,
+                    right: 0.0,
+                    bottom: 50.0,
+                    left: 10.0,
+                });
+
+            return iced::widget::stack![main, overlay].into();
+        }
+
         main.into()
     }
 }
@@ -1284,7 +1363,13 @@ pub enum PrismEvent {
     Run,
     EscapePressed,
     ExitApp,
+    /// Quit the whole app (bubbled to `Message::QuitAgent`), from the app menu.
+    QuitApp,
+    /// Begin dragging the Settings window (bubbled to `Message::DragSettingsWindow`).
+    DragSettingsWindow,
     ToggleActions,
+    /// Toggle the app menu (hamburger, bottom-left) popover.
+    ToggleMenu,
     /// The command/ctrl modifier was pressed (`true`) or released (`false`).
     ModifiersChanged(bool),
     InvokeAction(usize),

--- a/ui/src/prism/plugin_manager.rs
+++ b/ui/src/prism/plugin_manager.rs
@@ -14,8 +14,8 @@ use core::{AppState, PluginCommand, PluginRegistry, Preference, PreferenceKind, 
 use iced::{
     Alignment, Color, Element, Length,
     widget::{
-        Id, button, column, container, pick_list, row, scrollable, space::horizontal, text,
-        text_input,
+        Id, button, column, container, mouse_area, pick_list, row, scrollable, space::horizontal,
+        text, text_input,
     },
 };
 
@@ -24,6 +24,10 @@ use super::widgets::{scrollbar_style, slim_scrollbar};
 use crate::design_system::{colors, spacing, typo};
 
 // --- Settings-window palette (matched to the source design) -----------------
+
+/// Corner radius of the settings window chrome (and the title bar / master
+/// panel that sit flush against its edges).
+const WINDOW_RADIUS: f32 = 14.0;
 
 const WINDOW_BG: Color = Color::from_rgb8(0x1c, 0x1c, 0x1f);
 const TITLEBAR_BG: Color = Color::from_rgb8(0x2a, 0x2a, 0x2e);
@@ -154,9 +158,21 @@ pub struct PmCommand {
     pub hotkey: Option<String>,
 }
 
+/// Which settings tab is active. Only General and Extensions have panels;
+/// About stays presentational (as in the source design).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsTab {
+    General,
+    Extensions,
+}
+
 /// Interactions within the Plugin Manager.
 #[derive(Debug, Clone)]
 pub enum PmEvent {
+    /// Switch the active settings tab.
+    SelectTab(SettingsTab),
+    /// Toggle capture of a new launcher hotkey (armed until the next key press).
+    RecordHotkey,
     /// Show a plugin's details.
     Select(String),
     /// Flip a plugin's enabled switch.
@@ -191,6 +207,14 @@ pub enum PmEvent {
 
 /// Live state of the Plugin Manager screen.
 pub struct PluginManagerState {
+    /// The active settings tab (opens on General, matching the design).
+    pub tab: SettingsTab,
+    /// The launcher hotkey shown on the General tab. Only read by the non-Linux
+    /// recorder; on Linux the row shows "Not available".
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
+    pub launcher_hotkey: core::Hotkey,
+    /// Whether we are armed to capture a new launcher hotkey.
+    pub recording_hotkey: bool,
     pub plugins: Vec<PmPlugin>,
     pub selected_id: Option<String>,
     pub search: String,
@@ -205,6 +229,9 @@ impl PluginManagerState {
         let plugins = build_plugins(registry, app_state);
         let selected_id = plugins.first().map(|p| p.id.clone());
         Self {
+            tab: SettingsTab::General,
+            launcher_hotkey: app_state.launcher_hotkey(),
+            recording_hotkey: false,
             plugins,
             selected_id,
             search: String::new(),
@@ -427,7 +454,7 @@ pub fn view(state: &PluginManagerState) -> Element<'_, PrismEvent> {
     let window = column![
         title_bar(),
         chrome_line(),
-        tab_bar(),
+        tab_bar(state.tab),
         chrome_line(),
         body(state),
     ];
@@ -440,7 +467,7 @@ pub fn view(state: &PluginManagerState) -> Element<'_, PrismEvent> {
             border: iced::Border {
                 color: colors::ON_SURFACE.scale_alpha(0.12),
                 width: 1.0,
-                radius: 14.0.into(),
+                radius: WINDOW_RADIUS.into(),
             },
             ..Default::default()
         })
@@ -481,7 +508,7 @@ fn title_bar<'a>() -> Element<'a, PrismEvent> {
     .align_y(Alignment::Center)
     .spacing(spacing::SPACE_S);
 
-    container(bar)
+    let bar = container(bar)
         .width(Length::Fill)
         .center_y(Length::Fixed(44.0))
         .padding(iced::Padding {
@@ -492,8 +519,19 @@ fn title_bar<'a>() -> Element<'a, PrismEvent> {
         })
         .style(|_| container::Style {
             background: Some(TITLEBAR_BG.into()),
+            // Round the top corners to match the window chrome — `clip` alone
+            // clips to the bounds rectangle, not the rounded border.
+            border: iced::Border {
+                radius: iced::border::top(WINDOW_RADIUS),
+                ..Default::default()
+            },
             ..Default::default()
-        })
+        });
+
+    // Dragging the title bar moves the window. The traffic-light button captures
+    // its own clicks, so pressing it closes rather than starting a drag.
+    mouse_area(bar)
+        .on_press(PrismEvent::DragSettingsWindow)
         .into()
 }
 
@@ -542,12 +580,12 @@ fn traffic_light<'a>(color: Color) -> Element<'a, PrismEvent> {
         .into()
 }
 
-fn tab_bar<'a>() -> Element<'a, PrismEvent> {
-    // Tabs are presentational (as in the source design); Extensions is active.
+fn tab_bar<'a>(active: SettingsTab) -> Element<'a, PrismEvent> {
+    // General and Extensions switch panels; About stays presentational.
     let tabs = row![
-        tab_item("⚙", "General", false),
-        tab_item("▦", "Extensions", true),
-        tab_item("ⓘ", "About", false),
+        tab_item("⚙", "General", SettingsTab::General, active),
+        tab_item("▦", "Extensions", SettingsTab::Extensions, active),
+        tab_item_inert("ⓘ", "About"),
     ]
     .spacing(2.0)
     .align_y(Alignment::Center);
@@ -567,46 +605,255 @@ fn tab_bar<'a>() -> Element<'a, PrismEvent> {
         .into()
 }
 
-fn tab_item<'a>(icon: &str, label: &str, active: bool) -> Element<'a, PrismEvent> {
-    let fg = if active {
+/// A tab's icon-over-label content, tinted for its active/inactive state.
+fn tab_content<'a>(icon: &str, label: &str, fg: Color) -> Element<'a, PrismEvent> {
+    container(
+        column![
+            text(icon.to_string()).size(16.0).color(fg),
+            text(label.to_string())
+                .size(11.0)
+                .font(typo::LABEL_S.2)
+                .color(fg),
+        ]
+        .spacing(3.0)
+        .align_x(Alignment::Center),
+    )
+    .center_x(Length::Fixed(74.0))
+    .padding(iced::Padding {
+        top: 6.0,
+        right: 14.0,
+        bottom: 6.0,
+        left: 14.0,
+    })
+    .into()
+}
+
+/// A clickable settings tab that selects `tab`, highlighted when it is active.
+fn tab_item<'a>(
+    icon: &str,
+    label: &str,
+    tab: SettingsTab,
+    active: SettingsTab,
+) -> Element<'a, PrismEvent> {
+    let is_active = tab == active;
+    let fg = if is_active {
         colors::ON_SURFACE
     } else {
         colors::SECONDARY
     };
 
-    let content = column![
-        text(icon.to_string()).size(16.0).color(fg),
-        text(label.to_string())
-            .size(11.0)
-            .font(typo::LABEL_S.2)
-            .color(fg),
-    ]
-    .spacing(3.0)
-    .align_x(Alignment::Center);
-
-    container(content)
-        .center_x(Length::Fixed(74.0))
-        .padding(iced::Padding {
-            top: 6.0,
-            right: 14.0,
-            bottom: 6.0,
-            left: 14.0,
-        })
-        .style(move |_| container::Style {
-            background: active.then(|| colors::ON_SURFACE.scale_alpha(0.1).into()),
-            border: iced::Border {
-                radius: 8.0.into(),
+    button(tab_content(icon, label, fg))
+        .padding(0.0)
+        .on_press(PrismEvent::PluginManager(PmEvent::SelectTab(tab)))
+        .style(move |_, status| {
+            let hovered = status == button::Status::Hovered;
+            button::Style {
+                background: (is_active || hovered)
+                    .then(|| colors::ON_SURFACE.scale_alpha(0.1).into()),
+                border: iced::Border {
+                    radius: 8.0.into(),
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
+            }
         })
         .into()
 }
 
+/// A presentational (non-clickable) tab, e.g. About.
+fn tab_item_inert<'a>(icon: &str, label: &str) -> Element<'a, PrismEvent> {
+    tab_content(icon, label, colors::SECONDARY)
+}
+
 fn body(state: &PluginManagerState) -> Element<'_, PrismEvent> {
-    row![master(state), vline(Length::Fill), detail(state)]
+    match state.tab {
+        SettingsTab::General => general_body(state),
+        SettingsTab::Extensions => row![master(state), vline(Length::Fill), detail(state)]
+            .height(Length::Fill)
+            .into(),
+    }
+}
+
+// --- General tab ------------------------------------------------------------
+
+/// The General settings panel. Per the source design this is a scrollable form
+/// of grouped sections; only the Activation → Launcher hotkey row is wired up.
+fn general_body(state: &PluginManagerState) -> Element<'_, PrismEvent> {
+    let form = container(
+        column![activation_section(state)]
+            .spacing(28.0)
+            .width(Length::Fill),
+    )
+    .max_width(720.0)
+    .padding(iced::Padding {
+        top: 28.0,
+        right: 32.0,
+        bottom: 40.0,
+        left: 32.0,
+    });
+
+    scrollable(container(form).center_x(Length::Fill).width(Length::Fill))
         .height(Length::Fill)
+        .width(Length::Fill)
+        .direction(slim_scrollbar())
+        .style(scrollbar_style)
         .into()
+}
+
+/// The "Activation" group. Only the Launcher hotkey row is implemented.
+fn activation_section(state: &PluginManagerState) -> Element<'_, PrismEvent> {
+    column![
+        settings_section_header("Activation"),
+        settings_card(column![launcher_hotkey_row(state)]),
+    ]
+    .spacing(12.0)
+    .width(Length::Fill)
+    .into()
+}
+
+/// An uppercase group heading (e.g. "ACTIVATION").
+fn settings_section_header<'a>(label: &str) -> Element<'a, PrismEvent> {
+    text(label.to_uppercase())
+        .size(12.0)
+        .font(typo::LABEL_M.2)
+        .color(colors::SECONDARY)
+        .into()
+}
+
+/// The rounded, hairline-bordered card that wraps a group's rows.
+fn settings_card<'a>(rows: iced::widget::Column<'a, PrismEvent>) -> Element<'a, PrismEvent> {
+    container(rows)
+        .width(Length::Fill)
+        .style(|_| container::Style {
+            background: Some(colors::ON_SURFACE.scale_alpha(0.03).into()),
+            border: iced::Border {
+                color: colors::ON_SURFACE.scale_alpha(0.07),
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            ..Default::default()
+        })
+        .clip(true)
+        .into()
+}
+
+/// The Launcher hotkey row: a title/description on the left and, on the right, a
+/// recorder button showing the bound shortcut as keycaps. Clicking it arms
+/// capture; the next key press (handled at the app boundary) rebinds the global
+/// hotkey. Escape cancels.
+fn launcher_hotkey_row(state: &PluginManagerState) -> Element<'_, PrismEvent> {
+    let labels = column![
+        text("Launcher hotkey")
+            .size(14.0)
+            .font(typo::TITLE_S.2)
+            .color(colors::ON_SURFACE),
+        text("Global shortcut to open the launcher from anywhere.")
+            .size(12.0)
+            .color(colors::SECONDARY),
+    ]
+    .spacing(2.0)
+    .width(Length::Fill);
+
+    container(
+        row![labels, hotkey_recorder(state)]
+            .spacing(spacing::SPACE_M)
+            .align_y(Alignment::Center),
+    )
+    .width(Length::Fill)
+    .padding(iced::Padding {
+        top: 14.0,
+        right: 16.0,
+        bottom: 14.0,
+        left: 16.0,
+    })
+    .into()
+}
+
+/// The clickable hotkey control: a "Recording… press keys" prompt while armed,
+/// otherwise the current shortcut's keycaps.
+///
+/// On Linux the launcher shortcut is a compositor keybind, not something the app
+/// can register or rebind, so the control is replaced with a "Not available"
+/// note instead of an (unactionable) recorder.
+#[cfg(target_os = "linux")]
+fn hotkey_recorder(_state: &PluginManagerState) -> Element<'_, PrismEvent> {
+    text("Not available")
+        .size(13.0)
+        .color(colors::SECONDARY)
+        .into()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn hotkey_recorder(state: &PluginManagerState) -> Element<'_, PrismEvent> {
+    let recording = state.recording_hotkey;
+
+    let inner: Element<PrismEvent> = if recording {
+        text("Recording… press keys")
+            .size(13.0)
+            .color(colors::TERTIARY)
+            .into()
+    } else {
+        let mut keys = row![].spacing(5.0);
+        for cap in state.launcher_hotkey.keycaps() {
+            keys = keys.push(keycap(&cap));
+        }
+        keys.into()
+    };
+
+    button(inner)
+        .on_press(PrismEvent::PluginManager(PmEvent::RecordHotkey))
+        .padding(iced::Padding {
+            top: 2.0,
+            right: 4.0,
+            bottom: 2.0,
+            left: 4.0,
+        })
+        .style(move |_, status| {
+            let hovered = status == button::Status::Hovered;
+            button::Style {
+                background: (recording || hovered)
+                    .then(|| colors::ON_SURFACE.scale_alpha(0.05).into()),
+                border: iced::Border {
+                    color: if recording {
+                        colors::TERTIARY.scale_alpha(0.6)
+                    } else {
+                        Color::TRANSPARENT
+                    },
+                    width: if recording { 1.0 } else { 0.0 },
+                    radius: 8.0.into(),
+                },
+                ..Default::default()
+            }
+        })
+        .into()
+}
+
+/// A single keycap chip (monospace glyph in a subtle rounded box). Only the
+/// non-Linux recorder renders these (Linux shows "Not available").
+#[cfg(not(target_os = "linux"))]
+fn keycap<'a>(label: &str) -> Element<'a, PrismEvent> {
+    container(
+        text(label.to_string())
+            .font(typo::CODE_M.2)
+            .size(13.0)
+            .color(colors::ON_SURFACE),
+    )
+    .padding(iced::Padding {
+        top: 5.0,
+        right: 11.0,
+        bottom: 5.0,
+        left: 11.0,
+    })
+    .style(|_| container::Style {
+        background: Some(colors::ON_SURFACE.scale_alpha(0.06).into()),
+        border: iced::Border {
+            color: colors::ON_SURFACE.scale_alpha(0.14),
+            width: 1.0,
+            radius: 7.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
 }
 
 // --- Master (installed plugin list) -----------------------------------------
@@ -706,6 +953,12 @@ fn master(state: &PluginManagerState) -> Element<'_, PrismEvent> {
         .height(Length::Fill)
         .style(|_| container::Style {
             background: Some(MASTER_BG.into()),
+            // Round the bottom-left corner so the opaque master column follows
+            // the window chrome (the detail side is transparent and already does).
+            border: iced::Border {
+                radius: iced::border::bottom_left(WINDOW_RADIUS),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .into()

--- a/ui/src/prism/state.rs
+++ b/ui/src/prism/state.rs
@@ -100,6 +100,8 @@ pub struct PrismState {
     pub command_held: bool,
     pub show_actions: bool,
     pub actions_selected_index: usize,
+    /// Whether the app menu (hamburger, bottom-left) popover is open.
+    pub show_menu: bool,
     /// Recent arguments for the command currently in argument mode.
     pub recent_arguments: Vec<String>,
     /// Navigation stack of plugin views. Empty means the normal list; the last

--- a/ui/src/prism/widgets.rs
+++ b/ui/src/prism/widgets.rs
@@ -655,16 +655,171 @@ fn footer_shell<'a, Message: 'a>(bar: Row<'a, Message>) -> Element<'a, Message> 
     .into()
 }
 
-/// The bottom action bar. Shows the selected item's tile and its primary
-/// action, plus the Actions (⌘K) affordance; falls back to a no-selection
-/// state when nothing is selected.
-pub fn footer<'a, Message: 'a>(selected: Option<&'a ListEntry>) -> Element<'a, Message> {
+/// The hamburger button at the far left of the launcher footer. Pressing it
+/// opens the app menu (Settings / Quit); the popover is anchored above it.
+pub fn menu_button<'a, Message: Clone + 'a>(on_press: Message) -> Element<'a, Message> {
+    let bar = || {
+        container("")
+            .width(Length::Fixed(13.0))
+            .height(Length::Fixed(1.5))
+            .style(|_| container::Style {
+                background: Some(colors::ON_SURFACE_VARIANT.into()),
+                border: iced::Border {
+                    radius: 1.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+    };
+
+    let glyph = container(column![bar(), bar(), bar()].spacing(3.0).align_x(Alignment::Center))
+        .center(Length::Fill);
+
+    button(glyph)
+        .on_press(on_press)
+        .width(Length::Fixed(26.0))
+        .height(Length::Fixed(26.0))
+        .padding(0)
+        .style(|_theme, status| {
+            let hovered = status == button::Status::Hovered;
+            button::Style {
+                background: hovered.then(|| colors::ON_SURFACE.scale_alpha(0.1).into()),
+                border: iced::Border {
+                    radius: 6.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        })
+        .into()
+}
+
+/// Lighter red used for the destructive "Quit" label (`#FF6B72`).
+const QUIT_LABEL: Color = Color::from_rgb8(255, 107, 114);
+
+/// One row of the app menu popover: a colored glyph tile, a label, and a
+/// keyboard hint, with a per-row hover tint.
+struct AppMenuRow<Message> {
+    glyph: &'static str,
+    glyph_color: Color,
+    tile_bg: Color,
+    label: &'static str,
+    label_color: Color,
+    hint: &'static str,
+    hover_bg: Color,
+    on_press: Message,
+}
+
+fn app_menu_row<'a, Message: Clone + 'a>(row: AppMenuRow<Message>) -> Element<'a, Message> {
+    let AppMenuRow {
+        glyph,
+        glyph_color,
+        tile_bg,
+        label,
+        label_color,
+        hint,
+        hover_bg,
+        on_press,
+    } = row;
+
+    let tile = container(text(glyph.to_string()).size(13.0).color(glyph_color))
+        .center(Length::Fixed(22.0))
+        .style(move |_| container::Style {
+            background: Some(tile_bg.into()),
+            border: iced::Border {
+                radius: 6.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+    let content = row![
+        tile,
+        text(label).size(14.0).color(label_color),
+        horizontal(),
+        kbd(hint),
+    ]
+    .spacing(spacing::SPACE_M - spacing::SPACE_XS)
+    .align_y(Alignment::Center);
+
+    button(content)
+        .on_press(on_press)
+        .width(Length::Fill)
+        .padding(spacing::SPACE_S)
+        .style(move |_theme, status| {
+            let hovered = status == button::Status::Hovered;
+            button::Style {
+                background: hovered.then(|| hover_bg.into()),
+                text_color: label_color,
+                border: iced::Border {
+                    radius: 8.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        })
+        .into()
+}
+
+/// The app menu popover (hamburger, bottom-left): Open Settings + Quit. Styled
+/// to match the actions popover; anchored above the footer's menu button.
+pub fn app_menu<'a, Message: Clone + 'a>(
+    on_settings: Message,
+    on_quit: Message,
+) -> Element<'a, Message> {
+    let settings = app_menu_row(AppMenuRow {
+        glyph: "⚙",
+        glyph_color: colors::ON_SURFACE_VARIANT,
+        tile_bg: colors::ON_SURFACE.scale_alpha(0.1),
+        label: "Open Settings",
+        label_color: colors::ON_SURFACE,
+        hint: "⌘,",
+        hover_bg: colors::ON_SURFACE.scale_alpha(0.08),
+        on_press: on_settings,
+    });
+
+    let quit = app_menu_row(AppMenuRow {
+        glyph: "⏻",
+        glyph_color: colors::PRIMARY,
+        tile_bg: colors::PRIMARY.scale_alpha(0.16),
+        label: "Quit",
+        label_color: QUIT_LABEL,
+        hint: "⌘Q",
+        hover_bg: colors::PRIMARY.scale_alpha(0.12),
+        on_press: on_quit,
+    });
+
+    container(column![settings, quit].width(Length::Fill))
+        .width(Length::Fixed(224.0))
+        .padding(spacing::SPACE_S)
+        .style(|_| container::Style {
+            background: Some(Color::from_rgba8(30, 30, 33, 0.96).into()),
+            border: iced::Border {
+                color: colors::ON_SURFACE.scale_alpha(0.14),
+                width: 1.0,
+                radius: 12.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+/// The bottom action bar. A hamburger menu button sits at the far left; the
+/// rest shows the selected item's tile and its primary action plus the Actions
+/// (⌘K) affordance, falling back to a no-selection state when nothing is
+/// selected.
+pub fn footer<'a, Message: Clone + 'a>(
+    selected: Option<&'a ListEntry>,
+    on_menu: Message,
+) -> Element<'a, Message> {
+    let menu = menu_button(on_menu);
+
     let bar = match selected {
         Some(entry) => {
             let primary = entry.primary_action_label();
 
             row![
-                render_icon(entry.icon(), icons::SM),
+                menu,
                 horizontal(),
                 text(primary).size(13.0).color(colors::ON_SURFACE),
                 kbd("↵"),
@@ -674,6 +829,7 @@ pub fn footer<'a, Message: 'a>(selected: Option<&'a ListEntry>) -> Element<'a, M
             ]
         }
         None => row![
+            menu,
             text("No selection").size(13.0).color(colors::SECONDARY),
             horizontal(),
             text("Clear search").size(13.0).color(colors::ON_SURFACE),

--- a/ui/src/tray_native.rs
+++ b/ui/src/tray_native.rs
@@ -25,14 +25,26 @@
 //! [`subscription`] drains from a helper thread and forwards into the iced event
 //! loop as [`Message`]s — the same shape as the Linux `tray` module.
 
+use std::cell::RefCell;
+use std::str::FromStr;
 use std::sync::{Once, OnceLock};
 
+use global_hotkey::GlobalHotKeyManager;
+use global_hotkey::hotkey::{Code, HotKey, Modifiers};
 use iced::Subscription;
 use iced::futures::channel::mpsc::Sender;
 
 use tray_icon::menu::MenuId;
 
 use crate::app::Message;
+
+thread_local! {
+    /// The global-hotkey manager and the currently-registered hotkey, kept on
+    /// the main thread (where they were created — the crates require it) for the
+    /// process lifetime. Held here rather than leaked so [`rebind`] can
+    /// unregister the old key before registering a new one.
+    static HOTKEY: RefCell<Option<(GlobalHotKeyManager, HotKey)>> = const { RefCell::new(None) };
+}
 
 /// Menu-item ids, captured at install time so the event thread can tell which
 /// item fired (muda identifies menu events only by id).
@@ -44,17 +56,55 @@ static QUIT_ID: OnceLock<MenuId> = OnceLock::new();
 ///
 /// MUST be called on the main thread with the event loop running — call it from
 /// `Raycast::update` (see the module docs for why). Safe to call on every update;
-/// the [`Once`] collapses all but the first to a cheap atomic load.
-pub fn ensure_installed() {
+/// the [`Once`] collapses all but the first to a cheap atomic load. `hotkey` is
+/// the launcher shortcut to register on that first call (subsequent calls, and
+/// later rebinds, go through [`rebind`]).
+pub fn ensure_installed(hotkey: &core::Hotkey) {
     static INSTALL: Once = Once::new();
     INSTALL.call_once(|| {
-        if let Err(error) = install() {
+        if let Err(error) = install(hotkey) {
             eprintln!("tray/hotkey: failed to initialise: {error}");
         }
     });
 }
 
-fn install() -> anyhow::Result<()> {
+/// Translate a persisted [`core::Hotkey`] into the global-hotkey registration
+/// type. Fails only if the stored key `code` is not a recognised W3C code name.
+fn to_hotkey(hotkey: &core::Hotkey) -> anyhow::Result<HotKey> {
+    let mut mods = Modifiers::empty();
+    mods.set(Modifiers::CONTROL, hotkey.ctrl);
+    mods.set(Modifiers::ALT, hotkey.alt);
+    mods.set(Modifiers::SHIFT, hotkey.shift);
+    mods.set(Modifiers::META, hotkey.meta);
+
+    let code = Code::from_str(&hotkey.code)
+        .map_err(|_| anyhow::anyhow!("unknown key code {:?}", hotkey.code))?;
+
+    let mods = (!mods.is_empty()).then_some(mods);
+    Ok(HotKey::new(mods, code))
+}
+
+/// Re-register the launcher hotkey: unregister the current one and register
+/// `hotkey` in its place. Called from `Raycast::update` (main thread) after the
+/// user records a new shortcut. A no-op if the manager isn't installed yet.
+pub fn rebind(hotkey: &core::Hotkey) -> anyhow::Result<()> {
+    let new = to_hotkey(hotkey)?;
+    HOTKEY.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let Some((manager, current)) = slot.as_mut() else {
+            return Ok(());
+        };
+        if new == *current {
+            return Ok(());
+        }
+        let _ = manager.unregister(*current);
+        manager.register(new)?;
+        *current = new;
+        Ok(())
+    })
+}
+
+fn install(hotkey: &core::Hotkey) -> anyhow::Result<()> {
     use tray_icon::TrayIconBuilder;
     use tray_icon::menu::{Menu, MenuItem, PredefinedMenuItem};
 
@@ -81,13 +131,15 @@ fn install() -> anyhow::Result<()> {
         .build()?;
     std::mem::forget(tray);
 
-    // Register the global hotkey. Leak the manager for the same reason (its
-    // `Drop` unregisters the key).
-    use global_hotkey::GlobalHotKeyManager;
-    use global_hotkey::hotkey::{Code, HotKey, Modifiers};
+    // Register the global hotkey and keep the manager alive in the main thread's
+    // `HOTKEY` slot (not leaked) so `rebind` can unregister it later. The
+    // thread-local lives for the process, so the key stays registered.
     let manager = GlobalHotKeyManager::new()?;
-    manager.register(HotKey::new(Some(Modifiers::ALT), Code::Space))?;
-    std::mem::forget(manager);
+    let key = to_hotkey(hotkey).unwrap_or_else(|_| {
+        HotKey::new(Some(Modifiers::ALT), Code::Space)
+    });
+    manager.register(key)?;
+    HOTKEY.with(|cell| *cell.borrow_mut() = Some((manager, key)));
 
     Ok(())
 }

--- a/ui/src/tray_native.rs
+++ b/ui/src/tray_native.rs
@@ -166,14 +166,15 @@ fn event_stream() -> impl iced::futures::Stream<Item = Message> {
         // each thread *blocks* on `recv()`: the event is forwarded the instant it
         // arrives, with none of the latency a poll-and-sleep loop would add.
 
-        // Global-hotkey presses show the launcher (ignore the release half).
+        // Global-hotkey presses toggle the launcher (ignore the release half):
+        // press once to open, again to dismiss.
         let mut hotkey_sender = output.clone();
         std::thread::spawn(move || {
             use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
             let hotkeys = GlobalHotKeyEvent::receiver();
             while let Ok(event) = hotkeys.recv() {
                 if event.state == HotKeyState::Pressed {
-                    let _ = hotkey_sender.try_send(Message::Show);
+                    let _ = hotkey_sender.try_send(Message::Toggle);
                 }
             }
         });


### PR DESCRIPTION
## What

Three launcher/settings enhancements, implemented from the *Raycast Concepts* / *General Settings* design references.

### 1. Footer app menu
A hamburger button at the bottom-left of the launcher footer opens a small popover with **Open Settings** (`⌘,`) and **Quit** (`⌘Q`, red). Styled to match the existing actions popover; Esc / re-click dismisses it. `Quit` performs a full agent quit (`QuitAgent`), not just hiding the launcher.

### 2. Rebindable launcher hotkey
The **General** settings tab is now functional (tabs switch panels; About stays presentational) and implements the **Launcher hotkey** row:
- New serializable `core::Hotkey { ctrl, alt, shift, meta, code }` persisted on `AppState` (defaults to Alt/Option+Space), registered at boot.
- The `GlobalHotKeyManager` now lives in a main-thread `thread_local` (instead of being leaked) so the shortcut can be **unregistered + re-registered** at runtime.
- Clicking the hotkey chip arms capture; the next real key press is caught at the app boundary (`event::listen()`), converted, **persisted + rebound + redisplayed**. Esc cancels; a recording guard stops stray chords (⌘Q etc.) firing mid-capture.
- Physical key codes are used, so bindings are keyboard-layout-independent.
- **Linux**: the shortcut is a compositor keybind the app can't register, so the row shows **"Not available"** instead of a recorder.

### 3. Movable Settings window
The Settings surface is now its own **borderless, movable window** on Windows/macOS (Linux already had a separate window):
- Opens on manager-open and hides the launcher (as Raycast dismisses the launcher for Preferences); closes back to hidden.
- Draggable via the custom title bar (`mouse_area` → `window::drag`); the red traffic-light still closes.
- **Rounded corners**: `clip` only clips to the bounds rectangle, so the opaque title bar (top) and master panel (bottom-left) are rounded per-corner to follow the 14px chrome radius.

## Notes for reviewers
- `cargo check` + `clippy` clean on Windows (only the pre-existing `namespace` dead-code warning remains); the binary links cleanly. The Linux `cfg` paths were not compiled on this Windows host, but the gated code only uses cross-platform iced APIs.
- The Settings default landing tab is now **General**; the plugin list is one click away under **Extensions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)