### PR TITLE
fix(windows): list launchable apps from the shell AppsFolder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "ureq",
  "walkdir",
  "which",
+ "windows 0.56.0",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,3 +31,11 @@ app-info = "0.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 app-info = "0.1.0"
+windows = { version = "0.56", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
+    "Win32_Graphics_Gdi",
+    "Win32_Graphics_Imaging",
+] }

--- a/core/src/application/windows.rs
+++ b/core/src/application/windows.rs
@@ -1,11 +1,44 @@
 use crate::{Application, Image};
-use std::path::PathBuf;
+use std::ffi::c_void;
+use std::process::Command;
+use windows::Win32::Foundation::SIZE;
+use windows::Win32::Graphics::Gdi::DeleteObject;
+use windows::Win32::Graphics::Imaging::{
+    CLSID_WICImagingFactory, GUID_WICPixelFormat32bppBGRA, GUID_WICPixelFormat32bppRGBA,
+    IWICImagingFactory, WICBitmapUseAlpha, WICRect,
+};
+use windows::Win32::System::Com::{
+    CLSCTX_ALL, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx, CoTaskMemFree,
+    CoUninitialize,
+};
+use windows::Win32::UI::Shell::{
+    BHID_EnumItems, IEnumShellItems, IShellItem, IShellItemImageFactory,
+    SHCreateItemFromParsingName, SIGDN, SIGDN_NORMALDISPLAY, SIGDN_PARENTRELATIVEPARSING,
+    SIIGBF_BIGGERSIZEOK, SIIGBF_ICONONLY,
+};
+use windows::core::{Interface, w};
+
+/// Size, in pixels, of the icons we request from the shell for each app.
+const ICON_SIZE: i32 = 32;
 
 #[derive(Clone, Debug)]
 pub struct WindowsApplication {
     pub name: String,
-    pub path: PathBuf,
+    /// The app's parsing name relative to the shell `AppsFolder` — an
+    /// AppUserModelID for Store/UWP apps (`…_8wekyb3d8bbwe!App`) or a link
+    /// identifier for classic apps. Launched via `shell:AppsFolder\<app_id>`.
+    pub app_id: String,
     pub icon: Option<Image>,
+}
+
+/// Restores the COM reference count taken by our `CoInitializeEx` when the
+/// enumeration finishes.
+struct ComGuard;
+
+impl Drop for ComGuard {
+    fn drop(&mut self) {
+        unsafe { CoUninitialize() };
+    }
 }
 
 impl Application for WindowsApplication {
@@ -13,22 +46,12 @@ impl Application for WindowsApplication {
     where
         Self: Sized,
     {
-        app_info::get_installed_apps(32)
-            .map(|installed_apps| {
-                installed_apps
-                    .into_iter()
-                    .map(|app| {
-                        let icon = app.icon.map(|i| Image::Rgba(i.width, i.height, i.pixels));
-
-                        WindowsApplication {
-                            name: app.name,
-                            path: app.path,
-                            icon,
-                        }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
+        // The shell `AppsFolder` is the virtual folder backing Start → "All
+        // apps": it lists both classic Win32 programs and Store/UWP apps, the
+        // curated set a user actually launches — unlike the registry's
+        // `…\Uninstall` keys, which also contain redistributables, SDKs, driver
+        // packages and KB updates, and so produced an unusably long list.
+        unsafe { enumerate_apps_folder() }.unwrap_or_default()
     }
 
     fn name(&self) -> &str {
@@ -40,7 +63,7 @@ impl Application for WindowsApplication {
     }
 
     fn description(&self) -> Option<&str> {
-        self.path.to_str()
+        None
     }
 
     fn icon(&self) -> Option<Image> {
@@ -48,11 +71,117 @@ impl Application for WindowsApplication {
     }
 
     fn execute(&self, _arg: Option<String>) -> anyhow::Result<()> {
-        std::process::Command::new("cmd")
-            .args(["/c", "start", ""])
-            .arg(&self.path)
+        // Handing the `shell:AppsFolder\<id>` moniker to Explorer lets the shell
+        // activate the app the same way the Start menu does — this is the only
+        // launch path that works for both Win32 and Store/UWP apps.
+        Command::new("explorer.exe")
+            .arg(format!("shell:AppsFolder\\{}", self.app_id))
             .spawn()?;
 
         Ok(())
     }
+}
+
+/// Enumerates every entry in the shell `AppsFolder`, resolving each one's
+/// display name, launch id and icon.
+unsafe fn enumerate_apps_folder() -> windows::core::Result<Vec<WindowsApplication>> {
+    // Only balance the ref count when *we* initialized COM on this thread; if
+    // the caller already did (returning S_FALSE / RPC_E_CHANGED_MODE), leave it
+    // to them.
+    let _com = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }
+        .is_ok()
+        .then_some(ComGuard);
+
+    let apps_folder: IShellItem =
+        unsafe { SHCreateItemFromParsingName(w!("shell:AppsFolder"), None) }?;
+    let items: IEnumShellItems = unsafe { apps_folder.BindToHandler(None, &BHID_EnumItems) }?;
+
+    // A single WIC factory, reused to turn each shell icon into RGBA pixels.
+    let imaging: IWICImagingFactory =
+        unsafe { CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_ALL) }?;
+
+    let mut apps = Vec::new();
+    loop {
+        let mut buffer: [Option<IShellItem>; 1] = [None];
+        let mut fetched = 0u32;
+
+        if unsafe { items.Next(&mut buffer, Some(&mut fetched)) }.is_err() || fetched == 0 {
+            break;
+        }
+
+        let Some(item) = buffer[0].take() else {
+            break;
+        };
+
+        let names = unsafe {
+            (
+                display_name(&item, SIGDN_NORMALDISPLAY),
+                display_name(&item, SIGDN_PARENTRELATIVEPARSING),
+            )
+        };
+        let (Some(name), Some(app_id)) = names else {
+            continue;
+        };
+
+        let icon = item
+            .cast::<IShellItemImageFactory>()
+            .ok()
+            .and_then(|factory| unsafe { icon_pixels(&factory, &imaging) });
+
+        apps.push(WindowsApplication { name, app_id, icon });
+    }
+
+    Ok(apps)
+}
+
+/// Reads one of a shell item's display names, freeing the shell-allocated
+/// string afterwards.
+unsafe fn display_name(item: &IShellItem, kind: SIGDN) -> Option<String> {
+    let pwstr = unsafe { item.GetDisplayName(kind) }.ok()?;
+    let value = unsafe { pwstr.to_string() }.ok();
+    unsafe { CoTaskMemFree(Some(pwstr.0 as *const c_void)) };
+    value.filter(|s| !s.is_empty())
+}
+
+/// Renders a shell item's icon into an RGBA image via WIC.
+unsafe fn icon_pixels(
+    factory: &IShellItemImageFactory,
+    imaging: &IWICImagingFactory,
+) -> Option<Image> {
+    let size = SIZE {
+        cx: ICON_SIZE,
+        cy: ICON_SIZE,
+    };
+    let bitmap = unsafe { factory.GetImage(size, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK) }.ok()?;
+
+    let image = (|| {
+        let wic =
+            unsafe { imaging.CreateBitmapFromHBITMAP(bitmap, None, WICBitmapUseAlpha) }.ok()?;
+
+        let format = unsafe { wic.GetPixelFormat() }.ok()?;
+        if format != GUID_WICPixelFormat32bppBGRA && format != GUID_WICPixelFormat32bppRGBA {
+            return None;
+        }
+
+        let rect = WICRect {
+            X: 0,
+            Y: 0,
+            Width: ICON_SIZE,
+            Height: ICON_SIZE,
+        };
+        let mut pixels = vec![0u8; (ICON_SIZE * ICON_SIZE * 4) as usize];
+        unsafe { wic.CopyPixels(&rect, ICON_SIZE as u32 * 4, &mut pixels) }.ok()?;
+
+        // The shell hands us BGRA; the UI expects RGBA.
+        if format == GUID_WICPixelFormat32bppBGRA {
+            for chunk in pixels.chunks_exact_mut(4) {
+                chunk.swap(0, 2);
+            }
+        }
+
+        Some(Image::Rgba(ICON_SIZE as u32, ICON_SIZE as u32, pixels))
+    })();
+
+    let _ = unsafe { DeleteObject(bitmap) };
+    image
 }


### PR DESCRIPTION
## What & why

On Windows the app list showed **way too many** entries. The backend enumerated the registry `…\CurrentVersion\Uninstall` keys, which contain every installer entry on the machine — redistributables, SDKs, driver packages, KB updates, runtime components — not just launchable apps.

This switches to enumerating the shell **`AppsFolder`**, the virtual folder backing Start → "All apps". It's the curated launcher list Windows itself uses.

### Why AppsFolder over the alternatives

| Source | Coverage | Problem |
|---|---|---|
| Registry `…\Uninstall` (before) | Everything | Hundreds of junk entries (redistributables, SDKs, drivers, updates) |
| Start Menu `.lnk` scan | Win32 apps with shortcuts | Misses UWP/Store apps (Calculator, Photos, Terminal…) and shortcut-less apps |
| **`AppsFolder` (this PR)** | Win32 **+** Store/UWP apps | The exact "All apps" set — nothing extra, nothing missing |

## What changed

- `lookup_applications` binds to `shell:AppsFolder` and walks it with `IEnumShellItems`, resolving each entry's display name, launch id (parsing name relative to AppsFolder) and icon (`IShellItemImageFactory` + WIC, BGRA→RGBA).
- The struct stores `app_id` instead of a filesystem `path`.
- `execute` launches via `explorer.exe shell:AppsFolder\<app_id>` — the one activation path that works for both classic and Store apps.
- COM is initialized per lookup with a guard that only un-initializes when we were the ones who initialized it, so a UI thread that already set up COM stays balanced.
- `description()` returns `None` — no more ugly file-path subtitle under each app.
- Adds the `windows` crate to core's Windows-only deps, pinned to `0.56` to match the version `app-info` already pulls in (no extra build).

## Reviewer notes

- Builds clean (`cargo build -p core`, no warnings), but this was only type-checked/built — **not** run on a live desktop. Worth a manual smoke test that apps launch and icons render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)