### PR TITLE
fix(launcher): single-line rows without comments + correct keyboard scrolling

### DIFF
--- a/ui/src/prism/mod.rs
+++ b/ui/src/prism/mod.rs
@@ -17,14 +17,12 @@ use core::{
     ViewResponse, get_entities, search::SearchEngine,
 };
 use iced::{
-    Element, Length, Rectangle, Size, Subscription, Task,
-    advanced::widget::{operate, operation},
+    Element, Length, Subscription, Task,
     event, keyboard,
     widget::{
         Id, column, container,
         operation::{focus, scroll_to},
         scrollable,
-        selector::{self, Selector},
     },
 };
 
@@ -50,8 +48,6 @@ impl Prism {
             scroll_id,
             viewport_height: 0.0,
             current_scroll_offset: 0.0,
-            height_cache: std::collections::HashMap::new(),
-            default_row_height: 54.0,
             show_argument_input: false,
             is_argument_input_active: false,
             command_held: false,
@@ -160,7 +156,7 @@ impl Prism {
                 self.state.all_entries = wrapped_entries.clone();
                 self.state.entries = wrapped_entries;
 
-                measure_all_visible_items(&self.state)
+                Task::none()
             }
 
             PrismEvent::SearchInput(query) => {
@@ -215,13 +211,10 @@ impl Prism {
 
                 self.state.entries = entries;
 
-                Task::batch(vec![
-                    scroll_to(
-                        self.state.scroll_id.clone(),
-                        scrollable::AbsoluteOffset { x: 0.0, y: 0.0 },
-                    ),
-                    measure_all_visible_items(&self.state),
-                ])
+                scroll_to(
+                    self.state.scroll_id.clone(),
+                    scrollable::AbsoluteOffset { x: 0.0, y: 0.0 },
+                )
             }
 
             PrismEvent::ArgumentInput(arg) => {
@@ -279,14 +272,6 @@ impl Prism {
                 }
                 self.state.selected_index = self.state.selected_index.saturating_sub(1);
                 smart_scroll(&self.state)
-            }
-
-            PrismEvent::ItemMeasured { id, rect } => {
-                if rect.height > 0.0 {
-                    self.state.height_cache.insert(id, rect.height);
-                    self.state.default_row_height = rect.height;
-                }
-                Task::none()
             }
 
             PrismEvent::EntrySelected(index) => {
@@ -655,15 +640,6 @@ impl Prism {
                 Task::none()
             }
 
-            PrismEvent::GridRowMeasured { id, height } => {
-                if height > 0.0
-                    && let Some(top) = self.state.views.last_mut()
-                {
-                    top.row_heights.insert(id, height);
-                }
-                Task::none()
-            }
-
             _ => Task::none(),
         }
     }
@@ -790,11 +766,7 @@ impl Prism {
                         scrollable::AbsoluteOffset { x: 0.0, y: 0.0 },
                     );
                 }
-                Task::batch(vec![
-                    reset_scroll,
-                    self.sync_grid_rows(true),
-                    self.ensure_grid_images(),
-                ])
+                Task::batch(vec![reset_scroll, self.ensure_grid_images()])
             }
             ViewResponse::Append(items) => {
                 if let Some(top) = self.state.views.last_mut() {
@@ -809,7 +781,7 @@ impl Prism {
                         top.loaded_count = grid_items.len();
                     }
                 }
-                Task::batch(vec![self.sync_grid_rows(false), self.ensure_grid_images()])
+                self.ensure_grid_images()
             }
             ViewResponse::Effect(effect) => {
                 let plugin_id = self
@@ -824,42 +796,40 @@ impl Prism {
     }
 
     /// Scroll the active grid so the selected cell stays visible under keyboard
-    /// navigation, using measured row heights (same approach as the list).
+    /// navigation. Row heights are derived deterministically from each row's
+    /// content (see [`views::grid_row_height`]) rather than measured.
     fn scroll_grid_to_selected(&mut self) -> Task<PrismEvent> {
         // Vertical gap between grid rows (matches `spacing::SPACE_M`) and the
         // scrollable's top padding (`spacing::SPACE_S`).
         const ROW_SPACING: f32 = 16.0;
         const TOP_PAD: f32 = 8.0;
-        const FALLBACK_ROW: f32 = 124.0;
 
         let Some(top) = self.state.views.last_mut() else {
             return Task::none();
         };
-        if !matches!(top.view.body, core::ViewBody::Grid { .. }) {
+        let core::ViewBody::Grid { items, columns } = &top.view.body else {
             return Task::none();
-        }
+        };
+        let columns = (*columns as usize).max(1);
+        let total_rows = items.len().div_ceil(columns);
+        let selected_row = (top.selected / columns).min(total_rows.saturating_sub(1));
 
-        let selected_row = top.selected / top.grid_columns();
-        // A measured row height to fall back to for rows not yet measured.
-        let default_row = top
-            .row_heights
-            .values()
-            .copied()
-            .next()
-            .unwrap_or(FALLBACK_ROW);
-        let height_of = |index: usize| {
-            top.row_ids
-                .get(index)
-                .and_then(|id| top.row_heights.get(id))
-                .copied()
-                .unwrap_or(default_row)
+        // A row is as tall as its tallest cell: taller when any cell in it
+        // carries a subtitle.
+        let row_height = |row: usize| -> f32 {
+            let start = row * columns;
+            let end = (start + columns).min(items.len());
+            let has_subtitle = items[start..end]
+                .iter()
+                .any(|item| item.subtitle.as_deref().is_some_and(|s| !s.is_empty()));
+            views::grid_row_height(has_subtitle)
         };
 
         let mut row_top = TOP_PAD;
         for row in 0..selected_row {
-            row_top += height_of(row) + ROW_SPACING;
+            row_top += row_height(row) + ROW_SPACING;
         }
-        let row_bottom = row_top + height_of(selected_row);
+        let row_bottom = row_top + row_height(selected_row);
 
         let viewport = if top.viewport_height > 0.0 {
             top.viewport_height
@@ -887,32 +857,6 @@ impl Prism {
             }
             None => Task::none(),
         }
-    }
-
-    /// Refresh the per-row ids for the active grid and measure their heights.
-    /// `reset` regenerates all ids (new search); otherwise ids are extended for
-    /// appended rows.
-    fn sync_grid_rows(&mut self, reset: bool) -> Task<PrismEvent> {
-        let Some(top) = self.state.views.last_mut() else {
-            return Task::none();
-        };
-        let core::ViewBody::Grid { items, columns } = &top.view.body else {
-            return Task::none();
-        };
-
-        let columns = (*columns as usize).max(1);
-        let rows = items.len().div_ceil(columns);
-
-        if reset {
-            top.row_ids.clear();
-            top.row_heights.clear();
-        }
-        while top.row_ids.len() < rows {
-            top.row_ids.push(Id::unique());
-        }
-        top.row_ids.truncate(rows);
-
-        measure_grid_rows(&top.row_ids)
     }
 
     /// Combined keyboard-nav response for a grid: keep the selection visible and
@@ -1356,10 +1300,6 @@ pub enum PrismEvent {
     EntriesLoaded(Vec<ListEntry>),
 
     Scrolled(scrollable::Viewport),
-    ItemMeasured {
-        id: Id,
-        rect: Rectangle,
-    },
     Run,
     EscapePressed,
     ExitApp,
@@ -1405,10 +1345,6 @@ pub enum PrismEvent {
         frames: Option<Vec<(iced::widget::image::Handle, u32)>>,
     },
     AnimationTick(std::time::Instant),
-    GridRowMeasured {
-        id: Id,
-        height: f32,
-    },
 
     // --- Plugin Manager (settings) ---
     /// Open the Plugin Manager settings screen.
@@ -1476,50 +1412,6 @@ mod tests {
     }
 }
 
-fn measure_all_visible_items(state: &PrismState) -> Task<PrismEvent> {
-    let tasks: Vec<Task<PrismEvent>> = state
-        .entries
-        .iter()
-        .map(|entry| measure_item(entry.id.clone()))
-        .collect();
-
-    Task::batch(tasks)
-}
-
-fn measure_item(id: Id) -> Task<PrismEvent> {
-    let selector = selector::id(id.clone()).find();
-    let operation = operation::map(selector, move |v| {
-        v.map(|widget| PrismEvent::ItemMeasured {
-            id: id.clone(),
-            rect: widget.bounds(),
-        })
-        .unwrap_or(PrismEvent::ItemMeasured {
-            id: id.clone(),
-            rect: Rectangle::with_size(Size::new(0.0, 0.0)),
-        })
-    });
-    operate(operation)
-}
-
-/// Measure each grid row's height (by its container id) into `GridRowMeasured`
-/// events — the grid analogue of [`measure_item`].
-fn measure_grid_rows(row_ids: &[Id]) -> Task<PrismEvent> {
-    let tasks: Vec<Task<PrismEvent>> = row_ids
-        .iter()
-        .map(|id| {
-            let id = id.clone();
-            let selector = selector::id(id.clone()).find();
-            let operation = operation::map(selector, move |v| PrismEvent::GridRowMeasured {
-                id: id.clone(),
-                height: v.map(|widget| widget.bounds().height).unwrap_or(0.0),
-            });
-            operate(operation)
-        })
-        .collect();
-
-    Task::batch(tasks)
-}
-
 /// Decode fetched image bytes into displayable frames. Handles are built once
 /// here (off the UI thread) so re-renders reuse the GPU textures.
 fn build_frames(bytes: Vec<u8>) -> Vec<(iced::widget::image::Handle, u32)> {
@@ -1580,24 +1472,18 @@ fn headers_above(state: &PrismState, index: usize) -> usize {
 
 fn smart_scroll(state: &PrismState) -> Task<PrismEvent> {
     let mut y_position = headers_above(state, state.selected_index) as f32 * HEADER_HEIGHT;
-    let mut target_height = state.default_row_height;
 
     for i in 0..state.selected_index {
         if let Some(entry) = state.entries.get(i) {
-            let h = *state
-                .height_cache
-                .get(&entry.id)
-                .unwrap_or(&state.default_row_height);
-            y_position += h;
+            y_position += widgets::list_row_height(&entry.entry);
         }
     }
 
-    if let Some(entry) = state.entries.get(state.selected_index) {
-        target_height = *state
-            .height_cache
-            .get(&entry.id)
-            .unwrap_or(&state.default_row_height);
-    }
+    let target_height = state
+        .entries
+        .get(state.selected_index)
+        .map(|entry| widgets::list_row_height(&entry.entry))
+        .unwrap_or(0.0);
 
     let item_top = y_position;
     let item_bottom = item_top + target_height;

--- a/ui/src/prism/state.rs
+++ b/ui/src/prism/state.rs
@@ -91,8 +91,6 @@ pub struct PrismState {
     pub scroll_id: Id,
     pub viewport_height: f32,
     pub current_scroll_offset: f32,
-    pub height_cache: HashMap<Id, f32>,
-    pub default_row_height: f32,
     pub show_argument_input: bool,
     pub is_argument_input_active: bool,
     /// Whether a command/ctrl modifier is currently held. Used to drop printable
@@ -144,10 +142,6 @@ pub struct ViewState {
     /// Last-known scroll offset and viewport height, for keyboard scroll-follow.
     pub scroll_offset: f32,
     pub viewport_height: f32,
-    /// One id per grid row (for measuring actual row heights).
-    pub row_ids: Vec<Id>,
-    /// Measured height of each grid row, keyed by its id.
-    pub row_heights: HashMap<Id, f32>,
 }
 
 impl ViewState {
@@ -180,8 +174,6 @@ impl ViewState {
             more_available: true,
             scroll_offset: 0.0,
             viewport_height: 0.0,
-            row_ids: Vec::new(),
-            row_heights: HashMap::new(),
         }
     }
 

--- a/ui/src/prism/views.rs
+++ b/ui/src/prism/views.rs
@@ -20,6 +20,24 @@ use crate::design_system::{colors, spacing, typo};
 const GRID_TITLE_HEIGHT: f32 = 32.0;
 /// Fixed height of a grid cell's optional subtitle (one line of `BODY_S`).
 const GRID_SUBTITLE_HEIGHT: f32 = 16.0;
+/// Fixed height of a grid cell's image tile.
+const GRID_IMAGE_HEIGHT: f32 = 96.0;
+
+/// The exact rendered height of a grid row, given whether any of its cells
+/// carry a subtitle. Cells are built from fixed-height pieces, so this is exact
+/// and keyboard-nav scroll math needs no (unreliable) async measurement.
+pub fn grid_row_height(has_subtitle: bool) -> f32 {
+    // Button padding (top + bottom) + image + image→title gap + title.
+    let base = 2.0 * spacing::SPACE_XS
+        + GRID_IMAGE_HEIGHT
+        + spacing::SPACE_XS
+        + GRID_TITLE_HEIGHT;
+    if has_subtitle {
+        base + spacing::SPACE_XS + GRID_SUBTITLE_HEIGHT
+    } else {
+        base
+    }
+}
 
 /// Render the active plugin view: header, optional search, body, footer.
 pub fn view_screen<'a>(
@@ -51,14 +69,9 @@ pub fn view_screen<'a>(
     screen = screen.push(super::widgets::divider());
 
     let body: Element<PrismEvent> = match &state.view.body {
-        ViewBody::Grid { columns, items } => grid_body(
-            *columns,
-            items,
-            state.selected,
-            images,
-            elapsed_ms,
-            &state.row_ids,
-        ),
+        ViewBody::Grid { columns, items } => {
+            grid_body(*columns, items, state.selected, images, elapsed_ms)
+        }
         ViewBody::List { items } => list_body(items, state.selected),
         ViewBody::Detail { body, metadata } => detail_body(body, metadata),
         ViewBody::Form { .. } => form_body(state),
@@ -145,7 +158,6 @@ fn grid_body<'a>(
     selected: usize,
     images: &'a ImageCache,
     elapsed_ms: u64,
-    row_ids: &'a [iced::widget::Id],
 ) -> Element<'a, PrismEvent> {
     let columns = columns.max(1) as usize;
     let mut grid = column![].spacing(spacing::SPACE_M);
@@ -161,12 +173,7 @@ fn grid_body<'a>(
             cells = cells.push(horizontal());
         }
 
-        // Tag the row with its id so the host can measure its height.
-        let row: Element<PrismEvent> = match row_ids.get(row_index) {
-            Some(id) => container(cells).id(id.clone()).into(),
-            None => cells.into(),
-        };
-        grid = grid.push(row);
+        grid = grid.push(cells);
     }
 
     grid.into()
@@ -242,7 +249,7 @@ fn image_tile(element: Element<'_, PrismEvent>) -> Element<'_, PrismEvent> {
     container(element)
         .center(Length::Fill)
         .width(Length::Fill)
-        .height(Length::Fixed(96.0))
+        .height(Length::Fixed(GRID_IMAGE_HEIGHT))
         .style(|_| container::Style {
             background: Some(colors::ON_SURFACE.scale_alpha(0.06).into()),
             border: iced::Border {

--- a/ui/src/prism/widgets.rs
+++ b/ui/src/prism/widgets.rs
@@ -340,6 +340,34 @@ pub fn divider<'a, Message: 'a>() -> Element<'a, Message> {
 }
 
 /// A clickable list entry with selection state styling
+/// Vertical breathing room above + below a list row's content (matches the
+/// button's vertical padding in [`list_item`]).
+const ROW_V_PADDING: f32 = 2.0 * spacing::SPACE_S;
+
+/// Pixel line height of a typography style (`font size × relative line-height`).
+fn line_height(style: typo::Style) -> f32 {
+    style.1.to_absolute(iced::Pixels(style.0)).0
+}
+
+/// Whether an entry renders a subtitle line (a non-empty comment/description).
+pub fn has_subtitle(entry: &ListEntry) -> bool {
+    entry.description().is_some_and(|d| !d.is_empty())
+}
+
+/// The exact rendered height of a list row, *derived from the same design
+/// tokens the row is built from* (icon size, type scale, spacing) rather than
+/// hardcoded. So adjusting the typography or spacing constants keeps rendering
+/// and keyboard-nav scroll math in lockstep automatically — no runtime
+/// measurement, no magic numbers to maintain.
+pub fn list_row_height(entry: &ListEntry) -> f32 {
+    let mut content = line_height(typo::TITLE_M);
+    if has_subtitle(entry) {
+        content += spacing::SPACE_XXS + line_height(typo::BODY_S);
+    }
+    // A row is as tall as the taller of its icon and its stacked text lines.
+    ROW_V_PADDING + content.max(icons::LG)
+}
+
 pub fn list_item<'a, Message>(
     entry: &'a ListEntry,
     is_selected: bool,
@@ -350,17 +378,25 @@ where
 {
     let kind: &str = entry.kind_label();
 
-    let content = row![
-        render_icon(entry.icon(), icons::LG),
-        column![
-            text(entry.name())
-                .typography(typo::TITLE_M)
-                .color(colors::ON_SURFACE),
-            text(entry.description().unwrap_or(""))
+    // Only carry a subtitle line when there's an actual comment; otherwise the
+    // row collapses to a single line instead of reserving empty vertical space.
+    let mut lines = column![
+        text(entry.name())
+            .typography(typo::TITLE_M)
+            .color(colors::ON_SURFACE),
+    ]
+    .spacing(spacing::SPACE_XXS);
+    if has_subtitle(entry) {
+        lines = lines.push(
+            text(entry.description().unwrap_or_default())
                 .typography(typo::BODY_S)
                 .color(colors::ON_SURFACE_VARIANT),
-        ]
-        .spacing(spacing::SPACE_XXS),
+        );
+    }
+
+    let content = row![
+        render_icon(entry.icon(), icons::LG),
+        lines,
         horizontal(),
         text(kind)
             .typography(typo::LABEL_L)
@@ -369,10 +405,20 @@ where
     .spacing(spacing::SPACE_M)
     .align_y(Alignment::Center);
 
+    // Pin each row to a fixed height (vertically centering its content) so the
+    // list has exactly two, predictable row heights.
+    let content = container(content).center_y(Length::Fill);
+
     button(content)
         .on_press(on_press)
         .width(Length::Fill)
-        .padding(spacing::SPACE_S)
+        .height(Length::Fixed(list_row_height(entry)))
+        .padding(iced::Padding {
+            top: 0.0,
+            bottom: 0.0,
+            left: spacing::SPACE_S,
+            right: spacing::SPACE_S,
+        })
         .style(move |_theme, status| {
             let is_hovered = status == button::Status::Hovered;
 


### PR DESCRIPTION
## What & why

Two related fixes to the launcher result list (and the plugin grid).

### 1. Single-line rows when there's no comment
List rows always rendered a subtitle line — `text(description.unwrap_or(""))` — so even entries with no comment reserved two lines of vertical height. Windows apps, which never carry a description, made this most visible: the whole app list looked padded out. Rows with no non-empty description now collapse to a single line.

### 2. Keyboard-arrow scrolling was wrong
Making rows variable-height surfaced a latent bug. Arrow-key scroll math relied on an async widget-measurement path (`find`-by-id → `ItemMeasured`) that **always returned height 0** — I confirmed this by instrumenting and running the app. `height_cache` therefore stayed empty and `smart_scroll` used a fixed `54px` for every row. That was harmless while all rows were the same height, but wrong the moment they varied, so the selected row drifted out of view as you navigated. The plugin **grid** used the same dead measurement with a mismatched `124px` fallback (real cells are 140/160px), so it was subtly off too.

## How it's fixed
Replaced runtime measurement with **deterministic heights derived from the design tokens the rows are built from**:
- **List** — `list_row_height` computes `2·SPACE_S + max(icon, title_line + optional(subtitle_line))` from the type scale, spacing, and icon size.
- **Grid** — `grid_row_height` sums the fixed image/title/subtitle boxes.

Rendering and scroll math now share one source of truth, so keyboard scrolling is exact regardless of how single/two-line rows (or subtitle/no-subtitle grid cells) are interleaved. Because the heights are *computed from* the constants rather than hardcoded, changing the typography/spacing tokens keeps rendering and scroll math in lockstep automatically — no async lag, no magic numbers.

Removed the now-dead measurement machinery: `ItemMeasured`/`GridRowMeasured` events + handlers, `height_cache`/`default_row_height`, `row_ids`/`row_heights`, and the `measure_*` helpers (net −69 lines).

## Notes for reviewers
- The measurement path was confirmed non-functional (returned 0) before this change; nothing that worked was removed.
- Genuine runtime measurement *is* possible in iced 0.14 (`selector::find` returns real bounds) but adds an async round-trip + one-frame lag + fallback for the first navigation after any list change — not worth it here where rows have only two predictable shapes. It'd be the right tool only if free-form variable-height rows are added later.

## Testing
- `cargo build -p iced_raycast` — clean (only the pre-existing `namespace` dead-code warning).
- `cargo test -p iced_raycast` — passes.
- Smoke-launched the app; no panics.